### PR TITLE
Choose a cache_k to more evenly split the K iterations.

### DIFF
--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -87,6 +87,8 @@ function _mul!(C, A, B, α, β, (packa, packb)::NTuple{2,Bool}, (cache_m, cache_
     end
     m, k, n = checkmulsize(C, A, B)
 
+    cache_k = cld(K, cld(K, cache_k)) # More evenly divide K
+    
     if packa || packb
         # get buffer
         Abuffersize = cache_m * cache_k

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -73,6 +73,8 @@ function mul!(C, A, B, α=true, β=false; cache_params=(cache_m=72, cache_k=256,
     return C
 end
 
+partition_k(k, cache_k) = cld(k, cld(k, cache_k))
+
 ###
 ### Lower-level `_mul!`
 ###
@@ -87,7 +89,7 @@ function _mul!(C, A, B, α, β, (packa, packb)::NTuple{2,Bool}, (cache_m, cache_
     end
     m, k, n = checkmulsize(C, A, B)
 
-    cache_k = cld(K, cld(K, cache_k)) # More evenly divide K
+    cache_k = partition_k(k, cache_k) # More evenly divide K
     
     if packa || packb
         # get buffer

--- a/test/gemm_tests.jl
+++ b/test/gemm_tests.jl
@@ -23,6 +23,12 @@ end
     end
 end
 
+@testset "Block size tests" begin
+    @test MaBLAS.partition_k(2000, 532) == 500
+    @test MaBLAS.partition_k(401, 400) == 201
+    @test MaBLAS.partition_k(900, 400) == 300
+end
+
 @testset "Clean up loop tests" begin
     _m, _k, _n = 8*3, 8, 6*5
     # lower cache_params to check clean up loops more easily


### PR DESCRIPTION
This more evenly divides the `K` iterations. So for example, if `K = 401` and `cache_k = 400`, it redefines `cache_k = 201`.